### PR TITLE
[Fix]: Correct IR deep-copy and return-target remapping in LocalFunctionGenerator  

### DIFF
--- a/aspectk-core-tests/src/commonTest/kotlin/io/github/molelabs/aspectk/tests/FunctionBodyAdviceTest.kt
+++ b/aspectk-core-tests/src/commonTest/kotlin/io/github/molelabs/aspectk/tests/FunctionBodyAdviceTest.kt
@@ -1,0 +1,317 @@
+/*
+ * Copyright (C) 2026 aspectk
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.molelabs.aspectk.tests
+
+import io.github.molelabs.aspectk.runtime.After
+import io.github.molelabs.aspectk.runtime.Around
+import io.github.molelabs.aspectk.runtime.Aspect
+import io.github.molelabs.aspectk.runtime.Before
+import io.github.molelabs.aspectk.runtime.JoinPoint
+import io.github.molelabs.aspectk.runtime.ProceedingJoinPoint
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@Suppress("UNUSED")
+class FunctionBodyAdviceTest {
+    @Target(AnnotationTarget.FUNCTION)
+    private annotation class TargetExample1
+
+    @Aspect
+    private object ExampleAspect1 {
+        @Around(TargetExample1::class)
+        fun doAround(pjp: ProceedingJoinPoint): Any? = pjp.proceed()
+    }
+
+    private class Example1 {
+        @TargetExample1
+        fun compute(): Int {
+            val a = 6
+            val b = a * 7
+            return b
+        }
+    }
+
+    @Test
+    fun `local variable referencing another local variable computes correctly under @Around`() {
+        assertEquals(42, Example1().compute())
+    }
+
+    @Target(AnnotationTarget.FUNCTION)
+    private annotation class TargetExample2
+
+    @Aspect
+    private object ExampleAspect2 {
+        @Around(TargetExample2::class)
+        fun doAround(pjp: ProceedingJoinPoint): Any? = pjp.proceed()
+    }
+
+    private class Example2 {
+        @TargetExample2
+        fun double(x: Int): Int {
+            val result = x * 2
+            return result
+        }
+    }
+
+    @Test
+    fun `local variable referencing a parameter computes correctly under @Around`() {
+        assertEquals(10, Example2().double(5))
+    }
+
+    @Target(AnnotationTarget.FUNCTION)
+    private annotation class TargetExample3
+
+    @Aspect
+    private object ExampleAspect3 {
+        @Around(TargetExample3::class)
+        fun doAround(pjp: ProceedingJoinPoint): Any? = pjp.proceed()
+    }
+
+    private class Example3 {
+        @TargetExample3
+        fun sumWithBase(): Int {
+            val base = 10
+            return listOf(1, 2, 3).sumOf { it + base }
+        }
+    }
+
+    @Test
+    fun `lambda capturing a local variable executes correctly under @Around`() {
+        assertEquals(36, Example3().sumWithBase())
+    }
+
+    @Target(AnnotationTarget.FUNCTION)
+    private annotation class TargetExample4
+
+    @Aspect
+    private object ExampleAspect4 {
+        @Around(TargetExample4::class)
+        fun doAround(pjp: ProceedingJoinPoint): Any? = pjp.proceed()
+    }
+
+    private class Example4 {
+        @TargetExample4
+        fun greet(name: String): String {
+            fun prefix() = "Hello"
+            return "${prefix()}, $name!"
+        }
+    }
+
+    @Test
+    fun `local function declaration inside body executes correctly under @Around`() {
+        assertEquals("Hello, World!", Example4().greet("World"))
+    }
+
+    @Target(AnnotationTarget.FUNCTION)
+    private annotation class TargetExample5
+
+    @Aspect
+    private object ExampleAspect5 {
+        var called = false
+
+        @Before(TargetExample5::class)
+        fun doBefore(jp: JoinPoint) {
+            called = true
+        }
+    }
+
+    private class Example5 {
+        @TargetExample5
+        fun classify(n: Int): String = when {
+            n < 0 -> "negative"
+            n == 0 -> "zero"
+            else -> "positive"
+        }
+    }
+
+    @Test
+    fun `when expression in body executes correctly under @Before`() {
+        val result = Example5().classify(1)
+        assertTrue(ExampleAspect5.called)
+        assertEquals("positive", result)
+    }
+
+    @Target(AnnotationTarget.FUNCTION)
+    private annotation class TargetExample6
+
+    @Aspect
+    private object ExampleAspect6 {
+        var called = false
+
+        @After(TargetExample6::class)
+        fun doAfter(jp: JoinPoint) {
+            called = true
+        }
+    }
+
+    private class Example6 {
+        @TargetExample6
+        fun safeOp(input: String?): String = try {
+            checkNotNull(input) { "null input" }
+            input.uppercase()
+        } catch (e: IllegalStateException) {
+            "fallback"
+        }
+    }
+
+    @Test
+    fun `try-catch block in body executes correctly under @After`() {
+        val result = Example6().safeOp(null)
+        assertTrue(ExampleAspect6.called)
+        assertEquals("fallback", result)
+    }
+
+    @Target(AnnotationTarget.FUNCTION)
+    private annotation class TargetExample7
+
+    @Aspect
+    private object ExampleAspect7 {
+        var called = false
+
+        @Before(TargetExample7::class)
+        fun doBefore(jp: JoinPoint) {
+            called = true
+        }
+    }
+
+    private class Example7 {
+        @TargetExample7
+        fun sumUpTo(n: Int): Int {
+            var total = 0
+            for (i in 1..n) total += i
+            return total
+        }
+    }
+
+    @Test
+    fun `for loop in body executes correctly under @Before`() {
+        val result = Example7().sumUpTo(10)
+        assertTrue(ExampleAspect7.called)
+        assertEquals(55, result)
+    }
+
+    @Target(AnnotationTarget.FUNCTION)
+    private annotation class TargetExample8
+
+    @Aspect
+    private object ExampleAspect8 {
+        @Around(TargetExample8::class)
+        fun doAround(pjp: ProceedingJoinPoint): Any? = pjp.proceed()
+    }
+
+    private class Example8 {
+        val multiplier = 3
+
+        @TargetExample8
+        fun scale(x: Int): Int {
+            val result = x * multiplier
+            return result
+        }
+    }
+
+    @Test
+    fun `member property access in body computes correctly under @Around`() {
+        assertEquals(12, Example8().scale(4))
+    }
+
+    // --- Case 9: 멤버 함수 호출 ---
+
+    @Target(AnnotationTarget.FUNCTION)
+    private annotation class TargetExample9
+
+    @Aspect
+    private object ExampleAspect9 {
+        @Around(TargetExample9::class)
+        fun doAround(pjp: ProceedingJoinPoint): Any? = pjp.proceed()
+    }
+
+    private class Example9 {
+        private fun triple(x: Int) = x * 3
+
+        @TargetExample9
+        fun compute(x: Int): Int {
+            val result = triple(x)
+            return result
+        }
+    }
+
+    @Test
+    fun `member function call in body computes correctly under @Around`() {
+        assertEquals(12, Example9().compute(4))
+    }
+
+    @Target(AnnotationTarget.FUNCTION)
+    private annotation class TargetExample10
+
+    @Aspect
+    private object ExampleAspect10 {
+        var called = false
+
+        @After(TargetExample10::class)
+        fun doAfter(jp: JoinPoint) {
+            called = true
+        }
+    }
+
+    private class Transformer {
+        fun transform(x: Int) = x + 100
+    }
+
+    private class Example10 {
+        private val transformer = Transformer()
+
+        @TargetExample10
+        fun process(x: Int): Int {
+            val result = transformer.transform(x)
+            return result
+        }
+    }
+
+    @Test
+    fun `external class function call in body executes correctly under @After`() {
+        val result = Example10().process(5)
+        assertTrue(ExampleAspect10.called)
+        assertEquals(105, result)
+    }
+
+    @Target(AnnotationTarget.FUNCTION)
+    private annotation class TargetExample11
+
+    @Aspect
+    private object ExampleAspect11 {
+        @Around(TargetExample11::class)
+        fun doAround(pjp: ProceedingJoinPoint): Any? = pjp.proceed()
+    }
+
+    private class Example11 {
+        @TargetExample11
+        fun generateWithCoroutine(): Int {
+            val numbers =
+                sequence {
+                    yield(10)
+                    yield(20)
+                    yield(12)
+                }
+            return numbers.sum()
+        }
+    }
+
+    @Test
+    fun `sequence builder (coroutine) in body executes correctly under @Around`() {
+        assertEquals(42, Example11().generateWithCoroutine())
+    }
+}

--- a/aspectk-core-tests/src/commonTest/kotlin/io/github/molelabs/aspectk/tests/FunctionBodyAdviceTest.kt
+++ b/aspectk-core-tests/src/commonTest/kotlin/io/github/molelabs/aspectk/tests/FunctionBodyAdviceTest.kt
@@ -46,7 +46,7 @@ class FunctionBodyAdviceTest {
     }
 
     @Test
-    fun `local variable referencing another local variable computes correctly under @Around`() {
+    fun `local variable referencing another local variable computes correctly under Around Aspect`() {
         assertEquals(42, Example1().compute())
     }
 
@@ -68,7 +68,7 @@ class FunctionBodyAdviceTest {
     }
 
     @Test
-    fun `local variable referencing a parameter computes correctly under @Around`() {
+    fun `local variable referencing a parameter computes correctly under Around Aspect`() {
         assertEquals(10, Example2().double(5))
     }
 
@@ -90,7 +90,7 @@ class FunctionBodyAdviceTest {
     }
 
     @Test
-    fun `lambda capturing a local variable executes correctly under @Around`() {
+    fun `lambda capturing a local variable executes correctly under Around Aspect`() {
         assertEquals(36, Example3().sumWithBase())
     }
 
@@ -112,7 +112,7 @@ class FunctionBodyAdviceTest {
     }
 
     @Test
-    fun `local function declaration inside body executes correctly under @Around`() {
+    fun `local function declaration inside body executes correctly under Around Aspect`() {
         assertEquals("Hello, World!", Example4().greet("World"))
     }
 
@@ -139,7 +139,7 @@ class FunctionBodyAdviceTest {
     }
 
     @Test
-    fun `when expression in body executes correctly under @Before`() {
+    fun `when expression in body executes correctly under Before Aspect`() {
         val result = Example5().classify(1)
         assertTrue(ExampleAspect5.called)
         assertEquals("positive", result)
@@ -169,7 +169,7 @@ class FunctionBodyAdviceTest {
     }
 
     @Test
-    fun `try-catch block in body executes correctly under @After`() {
+    fun `try-catch block in body executes correctly under After Aspect`() {
         val result = Example6().safeOp(null)
         assertTrue(ExampleAspect6.called)
         assertEquals("fallback", result)
@@ -198,7 +198,7 @@ class FunctionBodyAdviceTest {
     }
 
     @Test
-    fun `for loop in body executes correctly under @Before`() {
+    fun `for loop in body executes correctly under Before Aspect`() {
         val result = Example7().sumUpTo(10)
         assertTrue(ExampleAspect7.called)
         assertEquals(55, result)
@@ -224,7 +224,7 @@ class FunctionBodyAdviceTest {
     }
 
     @Test
-    fun `member property access in body computes correctly under @Around`() {
+    fun `member property access in body computes correctly under Around Aspect`() {
         assertEquals(12, Example8().scale(4))
     }
 
@@ -250,7 +250,7 @@ class FunctionBodyAdviceTest {
     }
 
     @Test
-    fun `member function call in body computes correctly under @Around`() {
+    fun `member function call in body computes correctly under Around Aspect`() {
         assertEquals(12, Example9().compute(4))
     }
 
@@ -282,7 +282,7 @@ class FunctionBodyAdviceTest {
     }
 
     @Test
-    fun `external class function call in body executes correctly under @After`() {
+    fun `external class function call in body executes correctly under After Aspect`() {
         val result = Example10().process(5)
         assertTrue(ExampleAspect10.called)
         assertEquals(105, result)
@@ -311,7 +311,7 @@ class FunctionBodyAdviceTest {
     }
 
     @Test
-    fun `sequence builder (coroutine) in body executes correctly under @Around`() {
+    fun `coroutine sequence builder in body executes correctly under Around Aspect`() {
         assertEquals(42, Example11().generateWithCoroutine())
     }
 }

--- a/aspectk-core/src/main/kotlin/io/github/molelabs/aspectk/core/ir/generator/LocalFunctionGenerator.kt
+++ b/aspectk-core/src/main/kotlin/io/github/molelabs/aspectk/core/ir/generator/LocalFunctionGenerator.kt
@@ -19,7 +19,6 @@ import io.github.molelabs.aspectk.core.ir.AspectKIrCompilerContext
 import io.github.molelabs.aspectk.core.ir.withIrBuilder
 import io.github.molelabs.aspectk.core.reportCompilerBug
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
-import org.jetbrains.kotlin.ir.IrStatement
 import org.jetbrains.kotlin.ir.builders.declarations.buildFun
 import org.jetbrains.kotlin.ir.builders.irBlockBody
 import org.jetbrains.kotlin.ir.declarations.IrFunction
@@ -49,8 +48,6 @@ internal class LocalFunctionGenerator(
      * constructor expression that references this local function.
      */
     fun generateLocalFunction(declaration: IrFunction): IrSimpleFunction {
-        val originalStatements =
-            (declaration.body as? IrBlockBody)?.statements?.toList().orEmpty()
         val valueParams =
             declaration.parameters.filter { it.kind == IrParameterKind.Regular }
         val localFuncName = $$"$$${declaration.name.asString()}"
@@ -64,7 +61,7 @@ internal class LocalFunctionGenerator(
                 }
 
         return if (localFunc.isNullOrEmpty()) {
-            buildLocalFunction(declaration, originalStatements, valueParams, localFuncName)
+            buildLocalFunction(declaration, valueParams, localFuncName)
         } else {
             localFunc.first() as? IrSimpleFunction ?: reportCompilerBug("Unexpected local function")
         }
@@ -76,7 +73,6 @@ internal class LocalFunctionGenerator(
      */
     private fun buildLocalFunction(
         declaration: IrFunction,
-        originalStatements: List<IrStatement>,
         valueParams: List<IrValueParameter>,
         localFuncName: String,
     ): IrSimpleFunction {
@@ -107,12 +103,14 @@ internal class LocalFunctionGenerator(
         val paramSubstitutions: Map<IrValueParameter, IrValueParameter> =
             valueParams.zip(localParams).associate { (outer, local) -> outer to local }
 
+        // Deep-copy the entire body in one pass so that intra-body variable references
+        // (e.g., `val b = a + 1`) are correctly remapped to the local function's own
+        // symbols.  Copying statement-by-statement would give each call its own SymbolRemapper,
         val copiedStatements =
-            originalStatements.map {
-                it.deepCopyWithSymbols(localFunc).transformStatement(
-                    BodyTransformer(localFunc, paramSubstitutions),
-                )
-            }
+            (declaration.body?.deepCopyWithSymbols(localFunc) as? IrBlockBody)
+                ?.statements
+                ?.map { it.transformStatement(BodyTransformer(localFunc, declaration, paramSubstitutions)) }
+                .orEmpty()
 
         localFunc.body =
             aspectKCompilerContext.withIrBuilder(localFunc.symbol) {
@@ -134,10 +132,18 @@ internal class LocalFunctionGenerator(
     @OptIn(UnsafeDuringIrConstructionAPI::class)
     private class BodyTransformer(
         private val localFunc: IrSimpleFunction,
+        private val declaration: IrFunction,
         private val paramSubstitutions: Map<IrValueParameter, IrValueParameter>,
     ) : IrElementTransformerVoid() {
         override fun visitReturn(expression: IrReturn): IrExpression {
-            expression.returnTargetSymbol = localFunc.symbol
+            // Only remap returns that target the outer function. After deepCopyWithSymbols,
+            // returns targeting the outer function still point to declaration.symbol (it is
+            // outside the copied subtree and is not remapped). Returns inside nested lambdas
+            // or local functions point to their own (newly deep-copied) symbols and must NOT
+            // be redirected to localFunc, or they would short-circuit the enclosing body.
+            if (expression.returnTargetSymbol == declaration.symbol) {
+                expression.returnTargetSymbol = localFunc.symbol
+            }
             return super.visitReturn(expression)
         }
 


### PR DESCRIPTION
## Problem                                                                                                                                                       
   
  Two bugs in LocalFunctionGenerator.buildLocalFunction caused @Around (and @After) advice to produce invalid IR or wrong runtime behavior when the target      
  function body contained local variables, lambdas, or nested coroutine builders.
                                                                                                                                                                
  ---                                                                     
  ## Bug 1 — Per-statement deepCopyWithSymbols breaks intra-body variable references
                                                                                                                                                                
  Root cause
                                                                                                                                                                
  The original implementation copied each statement of the function body individually:                                                                          
   ```kotlin
  originalStatements.map { it.deepCopyWithSymbols(localFunc) } 
```                                                                                                 
                                                                                                                                                                
  Each call to deepCopyWithSymbols creates its own SymbolRemapper. When statement 1 (val a = 1) is copied, a new symbol a' is registered only in that remapper's
   table. When statement 2 (val b = a + 1) is copied in a separate call, the new remapper has no knowledge of a', so the IrGetValue for a still points to the   
  original symbol declared in the outer function.                                                                                                               
                                                                          
  The JVM lowering phase then sees $work as capturing a from the outer function. But by the time codegen runs, the outer body has already been cleared by       
  statement.clear(), so there is no frame slot for a. This results in:
                                                                                                                                                                
  IllegalStateException: No mapping for symbol: VAR name:a type:kotlin.Int [val]
                                                                                                                                                                
  Fix
                                                                                                                                                                
  Deep-copy the entire body in a single pass so that one SymbolRemapper instance handles all intra-body references correctly:                                   
   ```kotlin
  (declaration.body?.deepCopyWithSymbols(localFunc) as? IrBlockBody)                                                                                            
      ?.statements                                                                                                                                              
      ?.map { it.transformStatement(BodyTransformer(localFunc, declaration, paramSubstitutions)) }                                                              
      .orEmpty()                                                                                                                                                
```
  ---                                                                                                                                                           
  ## Bug 2 — BodyTransformer.visitReturn remaps returns inside nested lambdas
                                                                                                                                                                
  Root cause
                                                                                                                                                                
  BodyTransformer.visitReturn unconditionally redirected every IrReturn it encountered to localFunc.symbol:                                                     
   ```kotlin
  override fun visitReturn(expression: IrReturn): IrExpression {                                                                                                
      expression.returnTargetSymbol = localFunc.symbol  // applied to ALL returns                                                                               
      return super.visitReturn(expression)
  }       
```                                                                                                                                                      
                                                                          
  After deepCopyWithSymbols, returns targeting the outer function still point to declaration.symbol (because it is outside the copied subtree and is not in the 
  remapping table). Returns inside nested lambdas or local functions point to their own newly-created symbols.
                                                                                                                                                                
  By remapping all of them to localFunc, the return inside a nested lambda such as listOf(1, 2, 3).sumOf { it + base } was redirected to exit $work instead of  
  the lambda. As a result, sumOf short-circuited after the first element (1 + 10 = 11 instead of 36). The same issue caused NoClassDefFoundError for bodies
  containing inner local function declarations.                                                                                                                 
                                                                          
  Fix

  Only remap returns that were originally targeting the outer function:
```kotlin
  override fun visitReturn(expression: IrReturn): IrExpression {
      if (expression.returnTargetSymbol == declaration.symbol) {                                                                                                
          expression.returnTargetSymbol = localFunc.symbol
      }                                                                                                                                                         
      return super.visitReturn(expression)                                
  }     
```                                                                                                                                                        
   