### PR TITLE
[Feat]: add support for Android Gradle Plugin

### DIFF
--- a/aspectk-plugin/build.gradle.kts
+++ b/aspectk-plugin/build.gradle.kts
@@ -39,4 +39,5 @@ gradlePlugin {
 dependencies {
     compileOnly(libs.kotlin.gradlePlugin)
     compileOnly(libs.kotlin.gradlePlugin.api)
+    compileOnly(libs.android.gradleApi)
 }

--- a/aspectk-plugin/src/main/kotlin/io/github/molelabs/aspectk/plugin/AspectKGradleSubPlugin.kt
+++ b/aspectk-plugin/src/main/kotlin/io/github/molelabs/aspectk/plugin/AspectKGradleSubPlugin.kt
@@ -15,8 +15,10 @@
  */
 package io.github.molelabs.aspectk.plugin
 
+import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.GradleException
 import org.gradle.api.Project
+import org.gradle.api.attributes.plugin.GradlePluginApiVersion
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.SourceSetContainer
 import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
@@ -49,6 +51,7 @@ internal class AspectKGradleSubPlugin : KotlinCompilerPluginSupportPlugin {
 
     @OptIn(ExperimentalBuildToolsApi::class, ExperimentalKotlinGradlePluginApi::class)
     override fun apply(target: Project) {
+        GradlePluginApiVersion.GRADLE_PLUGIN_API_VERSION_ATTRIBUTE
         val compilerVersionProvider =
             target.kotlinExtension.compilerVersion.map { KotlinToolingVersion(it) }
                 ?: target.provider { target.kotlinToolingVersion }
@@ -95,6 +98,15 @@ internal class AspectKGradleSubPlugin : KotlinCompilerPluginSupportPlugin {
                 .configure {
                     it.dependencies.addLater(aspectKRuntimeDependency)
                 }
+        }
+
+        target.pluginManager.withPlugin("com.android.base") {
+            val androidExtension = target.extensions.getByName("android") as CommonExtension<*, *, *, *, *, *>
+            androidExtension.sourceSets.configureEach { sourceSet ->
+                target.configurations.named(sourceSet.implementationConfigurationName).configure {
+                    it.dependencies.addLater(aspectKRuntimeDependency)
+                }
+            }
         }
 
         target.pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ kotlinx-coroutines = "1.10.2"
 mockk = "1.13.8"
 jetbrainsKotlinJvm = "2.3.20"
 mavenPublish = "0.34.0"
+android = "8.13.2"
 
 [libraries]
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
@@ -27,6 +28,7 @@ kotlin-compile-testing = { module = "dev.zacsweers.kctfork:core", version = "0.1
 kotlin-compiler-embeddable = {module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin"}
 vanniktech-publish-gradle = { group = "com.vanniktech", name = "gradle-maven-publish-plugin", version.ref = "mavenPublish" }
 gmazzo-buildconfig = "com.github.gmazzo.buildconfig:plugin:5.6.8"
+android-gradleApi = { module = "com.android.tools.build:gradle-api", version.ref = "android" }
 
 [plugins]
 diffplug-spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }


### PR DESCRIPTION
* Added `android-gradleApi` dependency to `libs.versions.toml`
* Configured `AspectKGradleSubPlugin` to automatically add the AspectK runtime dependency to Android projects using `com.android.base`
* Updated `aspectk-plugin` build script to include Android Gradle API as a `compileOnly` dependency